### PR TITLE
Cast Map to List

### DIFF
--- a/prettytime.py
+++ b/prettytime.py
@@ -4,7 +4,7 @@ from operator import itemgetter, neg, pos
 from dateutil.relativedelta import *
 
 TIME_LIST = ['seconds', 'minutes', 'hours', 'days', 'weeks', 'months', 'years']
-LOWER_TIME_LIST = map(itemgetter(slice(None, -1)), TIME_LIST)
+LOWER_TIME_LIST = list(map(itemgetter(slice(None, -1)), TIME_LIST))
 EXPANDED_TIME_LIST = TIME_LIST + LOWER_TIME_LIST
 
 class NegativeError(ValueError): pass

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 
 from distutils.core import setup
 setup(name='prettytime',
-      version='0.0.3',
+      version='0.0.4',
       py_modules=['prettytime'],
       author='JJ',
       author_email='JJ@jdotjdot.com',


### PR DESCRIPTION
Cast map to list so that concatenation works and no `TypeError` is thrown.